### PR TITLE
Added support for gaussian splatting ply file save

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ python viz_scripts/online_recon.py configs/iphone/splatam.py
 To run 3D Gaussian Splatting on the SplaTAM reconstruction, please use the following command:
 
 ```bash
-python scripts/post_splatam_opt.pt configs/iphone/post_splatam_opt.py
+python scripts/post_splatam_opt.py configs/iphone/post_splatam_opt.py
 ```
 
 To run 3D Gaussian Splatting on a dataset using ground truth poses, please use the following command:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ open3d==0.16.0
 torchmetrics
 cyclonedds
 pytorch-msssim
+plyfile==0.8.1
 git+https://github.com/JonathonLuiten/diff-gaussian-rasterization-w-depth.git@cb65e4b86bc3bd8ed42174b72a62e8d3a3a71110

--- a/venv_requirements.txt
+++ b/venv_requirements.txt
@@ -10,4 +10,5 @@ lpips
 torchmetrics
 cyclonedds
 pytorch-msssim
+plyfile==0.8.1
 git+https://github.com/JonathonLuiten/diff-gaussian-rasterization-w-depth.git@cb65e4b86bc3bd8ed42174b72a62e8d3a3a71110


### PR DESCRIPTION
### Issue

Although the output of the system is a Gaussian splatting, it does not save the file into a *standardized format*. Which means additional routines are required to visualize the result in the other Gaussian splatting visualizer.

### Changes

+ Added requirements for `plyfile==0.8.1` for Gaussian splatting support.
+ In `utils/common_utils.py`, added additional procedure for converting `params.npz` into `gsplat.ply`. Conversion does not preserve every information, e.g., trajectory is not recorded in Gaussian splatting format.
+ Changed a single character typo in README.md

### Related issue

https://github.com/spla-tam/SplaTAM/issues/22