### PR TITLE
Fix a 'bug' in prune_gaussians func

### DIFF
--- a/utils/slam_external.py
+++ b/utils/slam_external.py
@@ -177,8 +177,11 @@ def prune_gaussians(params, variables, optimizer, iter, prune_dict):
             if iter >= prune_dict['remove_big_after']:
                 big_points_ws = torch.exp(params['log_scales']).max(dim=1).values > 0.1 * variables['scene_radius']
                 to_remove = torch.logical_or(to_remove, big_points_ws)
-            params, variables = remove_points(to_remove, params, variables, optimizer)
-            torch.cuda.empty_cache()
+                
+            # if there actually is any point to be remove
+            if torch.nonzero(to_remove).shape[0] > 0:
+                params, variables = remove_points(to_remove, params, variables, optimizer)
+                torch.cuda.empty_cache()
         
         # Reset Opacities for all Gaussians
         if iter > 0 and iter % prune_dict['reset_opacities_every'] == 0 and prune_dict['reset_opacities']:


### PR DESCRIPTION
Change to prune Gaussians when there actually is any point need to remove. 

The old version will do remove_points even when to_remove is all false, which will discard all gradients by calling remove_points function, which leads to a waste of optimizing iteration. 

This happens (almost) every 1st iter in mapping. You can check it by running 'replica/splatam_s.py'. The number of gaussians didn't change after prune, but the gradient is gone.